### PR TITLE
Add grouped columns to the example and fix child columns

### DIFF
--- a/examples/cell_renderer/cell_renderer.py
+++ b/examples/cell_renderer/cell_renderer.py
@@ -12,6 +12,7 @@ def create_entry(id):
         "id": id,
         "name": f"name {id}",
         "custom1": f"custom1 {id}",
+        "custom2": f"{id * 10}",
         "check": not (id % 2),
     }
 
@@ -26,6 +27,18 @@ COLUMNS = [
         "name": "Red",
         "prop": "custom1",
         "cellTemplate": "trame.utils.datagrid.renderers.red",
+        "columnTemplate": "trame.utils.datagrid.renderers.colRed",
+    },
+    {
+        "name": "Red Group",
+        "children": [
+            {
+                "name": "Nested Red",
+                "prop": "custom2",
+                "size": 150,
+                "columnTemplate": "trame.utils.datagrid.renderers.colRed",
+            },
+        ],
         "columnTemplate": "trame.utils.datagrid.renderers.colRed",
     },
     {

--- a/examples/cell_renderer/renderers.js
+++ b/examples/cell_renderer/renderers.js
@@ -10,6 +10,9 @@ function decorateEntry(input) {
     for (const [key, value] of Object.entries(input)) {
         output[key] = toJSExpression(value);
     }
+    if (output.children) {
+        output.children = output.children.map(decorateEntry);
+    }
     return output;
 }
 


### PR DESCRIPTION
This merge request adds [grouped columns](https://revolist.github.io/revogrid/guide/column.grouping.html) to the custom renderer example and updates the example's JavaScript to account this.

The new example looks like this:

![image](https://github.com/user-attachments/assets/3288f8cf-427b-44b5-9e01-47450ec9df44)
